### PR TITLE
Tycho OSGi runtime cleanup & improvement

### DIFF
--- a/tycho-equinox-api/src/main/java/org/sonatype/tycho/equinox/EquinoxRuntimeLocator.java
+++ b/tycho-equinox-api/src/main/java/org/sonatype/tycho/equinox/EquinoxRuntimeLocator.java
@@ -10,8 +10,10 @@ public interface EquinoxRuntimeLocator
         throws Exception;
 
     /**
-     * Packages exported by embedding application. This allows embedded runtime import API classes from embedding
-     * application with Import-Package.
+     * Packages exported by embedding application. This allows embedded runtime import API classes
+     * from embedding application with Import-Package.
+     * 
+     * @return Packages exported by embedding application; never <code>null</code>
      */
     public List<String> getSystemPackagesExtra();
 }

--- a/tycho-equinox/src/main/java/org/sonatype/tycho/equinox/embedder/DefaultEquinoxEmbedder.java
+++ b/tycho-equinox/src/main/java/org/sonatype/tycho/equinox/embedder/DefaultEquinoxEmbedder.java
@@ -97,12 +97,8 @@ public class DefaultEquinoxEmbedder
         // this tells framework to use our classloader as parent, so it can see classes that we see
         properties.put( "osgi.parentClassloader", "fwk" );
 
-        // this tells framework to check parent classloader first
-        // TODO specific package names
-        properties.put( "org.osgi.framework.bootdelegation", "*" );
-
         List<String> packagesExtra = equinoxLocator.getSystemPackagesExtra();
-        if ( packagesExtra != null && !packagesExtra.isEmpty() )
+        if ( packagesExtra.size() > 0 )
         {
             StringBuilder sb = new StringBuilder();
             for ( String pkg : packagesExtra )
@@ -113,6 +109,7 @@ public class DefaultEquinoxEmbedder
                 }
                 sb.append( pkg );
             }
+            // make the system bundle export the given packages and load them from the parent class loader
             properties.put( "org.osgi.framework.system.packages.extra", sb.toString() );
         }
 
@@ -244,10 +241,10 @@ public class DefaultEquinoxEmbedder
         if ( serviceReferences == null || serviceReferences.length == 0 )
         {
             StringBuilder sb = new StringBuilder();
-            sb.append("Service is not registered class='").append(clazz).append("'");
+            sb.append( "Service is not registered class='" ).append( clazz ).append( "'" );
             if ( filter != null )
             {
-                sb.append("filter='").append(filter).append("'");
+                sb.append( "filter='" ).append( filter ).append( "'" );
             }
             throw new IllegalStateException( sb.toString() );
         }

--- a/tycho-p2-resolver/org.sonatype.tycho.p2.tools.impl/META-INF/MANIFEST.MF
+++ b/tycho-p2-resolver/org.sonatype.tycho.p2.tools.impl/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Description: Implementation of tools for generating, copying, and using p
 Bundle-SymbolicName: org.sonatype.tycho.p2.tools.impl
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.eclipse.equinox.p2.director.app;bundle-version="[1.0.200,2.0.0)",
- org.sonatype.tycho.p2.tools.facade,
  org.eclipse.equinox.p2.core;bundle-version="[2.0.2,3.0.0)",
  org.eclipse.equinox.p2.publisher;bundle-version="[1.1.2,2.0.0)",
  org.eclipse.equinox.p2.updatesite;bundle-version="[1.0.201,2.0.0)",
@@ -18,6 +17,10 @@ Require-Bundle: org.eclipse.equinox.p2.director.app;bundle-version="[1.0.200,2.0
  org.eclipse.equinox.p2.artifact.repository;bundle-version="[1.1.1,2.0.0)"
 Import-Package: org.osgi.framework;version="[1.5.0,2.0.0)",
  org.sonatype.tycho.p2.repository,
+ org.sonatype.tycho.p2.tools,
+ org.sonatype.tycho.p2.tools.director,
+ org.sonatype.tycho.p2.tools.mirroring,
+ org.sonatype.tycho.p2.tools.publisher,
  org.sonatype.tycho.p2.util
 Service-Component: OSGI-INF/directorapp.xml, OSGI-INF/publisherfactory.xml, OSGI-INF/mirrorapp.xml
 Bundle-Activator: org.sonatype.tycho.p2.tools.impl.Activator

--- a/tycho-p2/tycho-p2-facade/src/main/java/org/sonatype/tycho/p2/facade/internal/DefaultTychoP2RuntimeMetadata.java
+++ b/tycho-p2/tycho-p2-facade/src/main/java/org/sonatype/tycho/p2/facade/internal/DefaultTychoP2RuntimeMetadata.java
@@ -22,7 +22,6 @@ public class DefaultTychoP2RuntimeMetadata
         ARTIFACTS.add( newDependency( "org.sonatype.tycho", "tycho-p2-runtime", p2Version, "zip" ) );
         ARTIFACTS.add( newDependency( "org.sonatype.tycho", "org.sonatype.tycho.p2.impl", p2Version, "jar" ) );
         ARTIFACTS.add( newDependency( "org.sonatype.tycho", "org.sonatype.tycho.p2.maven.repository", p2Version, "jar" ) );
-        ARTIFACTS.add( newDependency( "org.sonatype.tycho", "org.sonatype.tycho.p2.tools.facade", p2Version, "jar" ) );
         ARTIFACTS.add( newDependency( "org.sonatype.tycho", "org.sonatype.tycho.p2.tools.impl", p2Version, "jar" ) );
     }
 

--- a/tycho-p2/tycho-p2-facade/src/main/java/org/sonatype/tycho/p2/facade/internal/TychoP2RuntimeLocator.java
+++ b/tycho-p2/tycho-p2-facade/src/main/java/org/sonatype/tycho/p2/facade/internal/TychoP2RuntimeLocator.java
@@ -32,10 +32,12 @@ public class TychoP2RuntimeLocator
     implements EquinoxRuntimeLocator
 {
     /**
-     * List of packages exported by org.sonatype.tycho.p2 artifact/bundle.
+     * List of packages exported by the bundles/JARs that serve as facade between the Maven and the
+     * OSGi class loaders.
      */
     public static final String[] SYSTEM_PACKAGES_EXTRA = { "org.sonatype.tycho.p2", "org.sonatype.tycho.p2.repository",
-        "org.sonatype.tycho.p2.resolver", "org.sonatype.tycho.p2.tools.director", "org.sonatype.tycho.p2.tools.mirroring" };
+        "org.sonatype.tycho.p2.resolver", "org.sonatype.tycho.p2.tools", "org.sonatype.tycho.p2.tools.director",
+        "org.sonatype.tycho.p2.tools.publisher", "org.sonatype.tycho.p2.tools.mirroring" };
 
     @Requirement
     private Logger logger;


### PR DESCRIPTION
The first commit corrects a mistake made when the new OSGi tools facade was introduced (30784a8).
The second commit changes the mechanism through which the facade classes are shared between the Maven and the OSGi world: org.osgi.framework.system.packages.extra is the right, clean way of doing this.
