### PR TITLE
small change to example to make m2e Tycho generate a manifest

### DIFF
--- a/tycho-demo/itp02/build01/pomfirst-bundle/pom.xml
+++ b/tycho-demo/itp02/build01/pomfirst-bundle/pom.xml
@@ -10,6 +10,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.2</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -19,6 +20,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.0.1</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>
@@ -28,6 +30,9 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <manifestLocation>META-INF</manifestLocation>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
I was initially confused that m2e Tycho did not generate a manifest for this project.  After Igor pointed me to a working example, I was able to figure out what needed to be added to the pom for a manifest to be generated.  I've tested this in a recent version of Eclipse, and a manifest is now produced.
Having this in place will help future users of these examples learn what Tycho and m2e can do for them.
