### PR TITLE
Allow the repository name to be set

### DIFF
--- a/tycho-p2-resolver/org.sonatype.tycho.p2.tools.facade/src/main/java/org/sonatype/tycho/p2/tools/mirroring/MirrorApplicationService.java
+++ b/tycho-p2-resolver/org.sonatype.tycho.p2.tools.facade/src/main/java/org/sonatype/tycho/p2/tools/mirroring/MirrorApplicationService.java
@@ -51,9 +51,10 @@ public interface MirrorApplicationService
      * @param flags Additional options. flag is a <em>bitwise OR</em>'ed combination of
      *            {@link #MIRROR_ARTIFACTS}, {@link #INCLUDE_ALL_DEPENDENCIES},
      *            {@link #REPOSITORY_COMPRESS}
+     * @param name The name for the target repository.
      * @throws FacadeException if a checked exception occurs while mirroring
      */
     public void mirror( RepositoryReferences sources, File destination, Collection<?/* IInstallableUnit */> rootUnits,
-                        BuildContext context, int flags )
+                        BuildContext context, int flags, String name )
         throws FacadeException;
 }

--- a/tycho-p2-resolver/org.sonatype.tycho.p2.tools.impl/src/main/java/org/sonatype/tycho/p2/tools/impl/mirroring/MirrorApplicationServiceImpl.java
+++ b/tycho-p2-resolver/org.sonatype.tycho.p2.tools.impl/src/main/java/org/sonatype/tycho/p2/tools/impl/mirroring/MirrorApplicationServiceImpl.java
@@ -31,7 +31,7 @@ public class MirrorApplicationServiceImpl
     private static final String MIRROR_FAILURE_MESSAGE = "Copying p2 repository content failed";
 
     public void mirror( RepositoryReferences sources, File destination, Collection<?> rootUnits, BuildContext context,
-                        int flags )
+                        int flags, String name )
         throws FacadeException
     {
         IProvisioningAgent agent = Activator.createProvisioningAgent( context.getTargetDirectory() );
@@ -44,6 +44,7 @@ public class MirrorApplicationServiceImpl
             final RepositoryDescriptor destinationDescriptor = new RepositoryDescriptor();
             destinationDescriptor.setLocation( destination.toURI() );
             destinationDescriptor.setAppend( true );
+            destinationDescriptor.setName( name );
             boolean compressed = ( flags & REPOSITORY_COMPRESS ) != 0;
             destinationDescriptor.setCompressed( compressed );
             if ( ( flags & MIRROR_ARTIFACTS ) != 0 )

--- a/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/sonatype/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/sonatype/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
@@ -43,6 +43,13 @@ public class AssembleRepositoryMojo
      * @parameter default-value="true"
      */
     private boolean compress;
+    
+    /**
+     * Defines the name of the p2 repository. The default value is the project name.
+     * 
+     * @parameter default-value="${project.name}"
+     */
+    private String repositoryName;
 
     /** @component */
     private RepositoryReferenceTool repositoryReferenceTool;
@@ -78,7 +85,7 @@ public class AssembleRepositoryMojo
             }
 
             MirrorApplicationService mirrorApp = p2.getService( MirrorApplicationService.class );
-            mirrorApp.mirror( sources, destination, rootIUs, getBuildContext(), flags );
+            mirrorApp.mirror( sources, destination, rootIUs, getBuildContext(), flags, repositoryName );
         }
         catch ( FacadeException e )
         {


### PR DESCRIPTION
This change allows the repository name to be set when using the tycho-p2-repository-plugin with the 'repositoryName' configuration property. If one is not set, the project name will be used.
