### PR TITLE
Allow to use Maven Toolchains for tycho-surefire

### DIFF
--- a/tycho-surefire/maven-osgi-test-plugin/pom.xml
+++ b/tycho-surefire/maven-osgi-test-plugin/pom.xml
@@ -25,6 +25,11 @@
       <artifactId>maven-plugin-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-toolchain</artifactId>
+      <version>2.0.9</version>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>


### PR DESCRIPTION
Patch for https://bugs.eclipse.org/bugs/show_bug.cgi?id=342353
Not a very good solution ( in comparison with proposed in https://issues.sonatype.org/browse/TYCHO-490 ), but straightforward and allows to use Toolchains for tycho-surefire.
